### PR TITLE
fix a bug: only the top-level block is enabled/disabled

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,9 +278,13 @@
         return;
       }
       var block = workspace.getBlockById(event.blockId);
+      if (!block) { return; } // necessary for shadow blocks
       var root = block.getRootBlock();
       var disable = (root.type != 'basics_setup' && root.type != 'basics_loop');
-      block.setDisabled(disable);
+      var desc = block.getDescendants();
+      for (var i = 0; i < desc.length; i++) {
+        desc[i].setDisabled(disable);
+      }
     }
 
     function showCodePy() {


### PR DESCRIPTION
ブロックのかたまりを「最初だけ」「ずっと」の中に入れたとき／中から出したとき，先頭ブロックのみ有効／無効が切り替わる不具合を修正しました。