### PR TITLE
Making this app runnable on Electron

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 closure-library
+node_modules/

--- a/elec.js
+++ b/elec.js
@@ -1,0 +1,12 @@
+var electron = require('electron');
+var app = electron.app;
+var BrowserWindow = electron.BrowserWindow;
+var mainWindow = null;
+app.on('ready', function () {
+    mainWindow = new BrowserWindow({ width:900, height:700 });
+    mainWindow.loadURL('file://' + __dirname + '/index.html');
+    mainWindow.on('closed', function () {
+        mainWindow = null;
+    });
+    //mainWindow.openDevTools(); // Dev Tools for debugging
+});

--- a/index.html
+++ b/index.html
@@ -14,6 +14,10 @@
   <script src="blockly/python_compressed.js"></script>
   <script src="blockly/msg/js/ja.js"></script>
   <script src="ledsimulator.js"></script>
+  <script src="node_modules/vex-js/dist/js/vex.combined.min.js"></script>
+  <script>vex.defaultOptions.className = 'vex-theme-os'</script>
+  <link rel="stylesheet" href="node_modules/vex-js/dist/css/vex.css" />
+  <link rel="stylesheet" href="node_modules/vex-js/dist/css/vex-theme-os.css" />
   <style>
     body {
       background-color: #fff;
@@ -477,19 +481,21 @@
     /** ブロックを保存 */
     function saveBlocks() {
       if ('localStorage' in window) {
-        var name = null;
-        while (!name) {
-          name = window.prompt('プログラム名を入力してください');
-          if (!name) { return; } // ignore if empty
-          if (window.localStorage[savedBlockPrefix + name]) {
+        var callback = function (name) {
+          if (name && window.localStorage[savedBlockPrefix + name]) {
             if (! window.confirm(name + ' は存在します。上書きしますか?')) {
-              name = null;
+              name = undefined;
             }
           }
-        }
-        name = savedBlockPrefix + name;
-        var xml = Blockly.Xml.workspaceToDom(workspace);
-        window.localStorage.setItem(name, Blockly.Xml.domToText(xml));
+          if (name === undefined) {
+            Blockly.prompt('プログラム名を入力してください', '', callback);
+          } else if (name) {
+            name = savedBlockPrefix + name;
+            var xml = Blockly.Xml.workspaceToDom(workspace);
+            window.localStorage.setItem(name, Blockly.Xml.domToText(xml));
+          }
+        };
+        callback(undefined);
       }
     }
     /** ブロックを復元 */
@@ -540,6 +546,20 @@
       if (event.target == modal) {
         cancelRestoreBlocks();
       }
+    }
+
+    var isNodeJs = (typeof process !== "undefined" && typeof require !== "undefined");
+
+    // Re-define Blockly.prompt() because window.prompt() is not
+    // supported by Electron.
+    if (isNodeJs) {
+      Blockly.prompt = function(message, defaultValue, callback) {
+        vex.dialog.prompt({
+          'message': message,
+          'value': defaultValue,
+          'callback': callback
+        });
+      };
     }
   </script>
 

--- a/index.html
+++ b/index.html
@@ -390,14 +390,14 @@
     function showCodePy() {
       // Generate Python code and display it.
       var code = Blockly.Python.workspaceToCode(workspace);
-      Blockly.alert(code);
+      alert(code);
     }
 
     function showCode() {
       // Generate JavaScript code and display it.
       Blockly.JavaScript.INFINITE_LOOP_TRAP = null;
       var code = Blockly.JavaScript.workspaceToCode(workspace);
-      Blockly.alert(code);
+      alert(code);
     }
 
     function runCode() {

--- a/index.html
+++ b/index.html
@@ -390,14 +390,14 @@
     function showCodePy() {
       // Generate Python code and display it.
       var code = Blockly.Python.workspaceToCode(workspace);
-      alert(code);
+      Blockly.alert(code);
     }
 
     function showCode() {
       // Generate JavaScript code and display it.
       Blockly.JavaScript.INFINITE_LOOP_TRAP = null;
       var code = Blockly.JavaScript.workspaceToCode(workspace);
-      alert(code);
+      Blockly.alert(code);
     }
 
     function runCode() {
@@ -464,11 +464,12 @@
 
     /** ブロックを全消去 */
     function clearBlocks() {
-      if (window.confirm('プログラムを消去してよいですか?')) {
+      Blockly.confirm('プログラムを消去してよいですか?', function (yes) {
+        if (!yes) { return; }
         workspace.clear();
         Blockly.Xml.domToWorkspace(document.getElementById('startBlocks'),
                                    workspace);
-      }
+      });
     }
 
     /** ローカルストレージに保存するときのキー接頭辞 */
@@ -477,21 +478,26 @@
     /** ブロックを保存 */
     function saveBlocks() {
       if ('localStorage' in window) {
-        var callback = function (name) {
-          if (name && window.localStorage[savedBlockPrefix + name]) {
-            if (! window.confirm(name + ' は存在します。上書きしますか?')) {
-              name = undefined;
+        var saveToFile = function (name) {
+          if (name === undefined) {
+            Blockly.prompt('プログラム名を入力してください', '', saveToFile);
+          } else if (name) {
+            var overwrite = function (yes) {
+              if (yes) {
+                var xml = Blockly.Xml.workspaceToDom(workspace);
+                window.localStorage.setItem(savedBlockPrefix + name, Blockly.Xml.domToText(xml));
+              } else {
+                saveToFile(undefined);
+              }
+            };
+            if (window.localStorage[savedBlockPrefix + name]) {
+              Blockly.confirm(name + ' は存在します。上書きしますか?', overwrite);
+            } else {
+              overwrite(true);
             }
           }
-          if (name === undefined) {
-            Blockly.prompt('プログラム名を入力してください', '', callback);
-          } else if (name) {
-            name = savedBlockPrefix + name;
-            var xml = Blockly.Xml.workspaceToDom(workspace);
-            window.localStorage.setItem(name, Blockly.Xml.domToText(xml));
-          }
         };
-        callback(undefined);
+        saveToFile(undefined);
       }
     }
     /** ブロックを復元 */
@@ -507,7 +513,7 @@
           }
         }
         if (items.length == 0) {
-          window.alert('保存されているプログラムはありません');
+          Blockly.alert('保存されているプログラムはありません');
           return;
         }
         items.sort();
@@ -530,7 +536,7 @@
         workspace.clear();
         Blockly.Xml.domToWorkspace(xml, workspace);
       } else {
-        window.alert('Error: ' + name + ' がありません');
+        Blockly.alert('Error: ' + name + ' がありません');
       }
     }
     function cancelRestoreBlocks() {
@@ -561,6 +567,20 @@
           'value': defaultValue,
           'callback': callback
         });
+      };
+      Blockly.confirm = function(message, callback) {
+        vex.defaultOptions.className = 'vex-theme-os';
+        vex.dialog.confirm({
+          'message': message,
+          'callback': callback
+        });
+      };
+      Blockly.alert = function(message, opt_callback) {
+        vex.defaultOptions.className = 'vex-theme-os';
+        vex.dialog.alert(message);
+        if (opt_callback) {
+          opt_callback();
+        }
       };
     }
 

--- a/index.html
+++ b/index.html
@@ -14,10 +14,6 @@
   <script src="blockly/python_compressed.js"></script>
   <script src="blockly/msg/js/ja.js"></script>
   <script src="ledsimulator.js"></script>
-  <script src="node_modules/vex-js/dist/js/vex.combined.min.js"></script>
-  <script>vex.defaultOptions.className = 'vex-theme-os'</script>
-  <link rel="stylesheet" href="node_modules/vex-js/dist/css/vex.css" />
-  <link rel="stylesheet" href="node_modules/vex-js/dist/css/vex-theme-os.css" />
   <style>
     body {
       background-color: #fff;
@@ -547,19 +543,40 @@
         cancelRestoreBlocks();
       }
     }
-
+  </script>
+  <script>
     var isNodeJs = (typeof process !== "undefined" && typeof require !== "undefined");
 
     // Re-define Blockly.prompt() because window.prompt() is not
     // supported by Electron.
     if (isNodeJs) {
+      loadJsCss("node_modules/vex-js/dist/js/vex.combined.min.js");
+      loadJsCss("node_modules/vex-js/dist/css/vex.css");
+      loadJsCss("node_modules/vex-js/dist/css/vex-theme-os.css");
+
       Blockly.prompt = function(message, defaultValue, callback) {
+        vex.defaultOptions.className = 'vex-theme-os';
         vex.dialog.prompt({
           'message': message,
           'value': defaultValue,
           'callback': callback
         });
       };
+    }
+
+    function loadJsCss(file) {
+      var elem;
+      if (file.substr(-4) == '.css') {
+        elem = document.createElement('link');
+        elem.rel  = 'stylesheet';
+        elem.href = file;
+      } else {
+        elem = document.createElement('script');
+        elem.type = 'text/javascript';
+        elem.src  = file;
+      }
+      var head = document.getElementsByTagName('head')[0];
+      head.appendChild(elem);
     }
   </script>
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "blockly-for-led",
+  "version": "0.1.0",
+  "main": "elec.js"
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,10 @@
 {
   "name": "blockly-for-led",
-  "version": "0.1.0",
-  "main": "elec.js"
+  "main": "elec.js",
+  "license": "Apache-2.0",
+  "repository": "kut-tktlab/blockly-for-led",
+  "dependencies": {
+    "vex-js": "^4.0.0"
+  },
+  "version": "0.1.0"
 }


### PR DESCRIPTION
[Electron](https://electron.atom.io)の上でも実行できるようにします (実LEDを動かすための伏線)。

ほぼ package.json と起動用js (elec.js) を追加するだけですが，[window.prompt() が使えない](https://github.com/electron/electron/issues/472)ので代替物が必要です (「変数の追加」などでwindow.prompt() が使われる)。
今回は [vex-js](http://github.hubspot.com/vex/docs/welcome/) を使うことにしました。

INSTALL:
```sh
$ npm install        # install vex-js
```

RUN:
```sh
$ electron .
```

TODO:
- [x] ブラウザで実行するときは vex-js 関係のjsやcssをロードしない。